### PR TITLE
fix: removed asyncBefore and asyncAfter from Json schema

### DIFF
--- a/resources/activiti.json
+++ b/resources/activiti.json
@@ -85,18 +85,6 @@
           "default": false
         },
         {
-          "name": "asyncBefore",
-          "isAttr": true,
-          "type": "Boolean",
-          "default": false
-        },
-        {
-          "name": "asyncAfter",
-          "isAttr": true,
-          "type": "Boolean",
-          "default": false
-        },
-        {
           "name": "exclusive",
           "isAttr": true,
           "type": "Boolean",


### PR DESCRIPTION
To remove Camunda's `asyncBefore` and `asyncAfterr` proprietory extestions from Json schema 